### PR TITLE
Revert "signature" of withCacheHeaders and get tests running

### DIFF
--- a/grails-app/controllers/com/grailsrocks/cacheheaders/TestController.groovy
+++ b/grails-app/controllers/com/grailsrocks/cacheheaders/TestController.groovy
@@ -36,4 +36,15 @@ class TestController implements CacheHeadersTrait {
 	def combinedStoreAndShareDefaultTest() {
 		cache store: false
 	}
+
+	def withCacheHeadersHasRequestAndResponseTest() {
+		withCacheHeaders {
+			etag {
+				"686897696a7c876b7e"
+			}
+			generate {
+				[:]
+			}
+		}
+	}
 }

--- a/src/integration-test/groovy/grails/plugins/cacheheaders/CacheMethodsSpec.groovy
+++ b/src/integration-test/groovy/grails/plugins/cacheheaders/CacheMethodsSpec.groovy
@@ -1,19 +1,17 @@
-package cacheheaders
+package grails.plugins.cacheheaders
+
+import grails.test.mixin.integration.Integration
+import org.springframework.beans.factory.annotation.Autowired
+import spock.lang.Specification
 
 import java.text.SimpleDateFormat
 
 import com.grailsrocks.cacheheaders.TestController
-import grails.test.mixin.integration.IntegrationTestMixin
-import grails.test.mixin.*
-import org.junit.*
-import test.*
 import static org.junit.Assert.*
 import grails.util.*
-import org.springframework.beans.factory.annotation.*
-import grails.plugins.cacheheaders.*
 
-@TestMixin(IntegrationTestMixin)
-class CacheMethodsTests {
+@Integration
+class CacheMethodsSpec extends Specification {
 
 	private static final String RFC1123_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz" // Always GMT
 
@@ -23,62 +21,82 @@ class CacheMethodsTests {
 	@Autowired
 	CacheHeadersService cacheHeadersService
 
-	void setUp() {
+	void setup() {
 		GrailsWebMockUtil.bindMockWebRequest()
 		con.cacheHeadersService = cacheHeadersService 
 	}
 
-	void testPresetCanTurnCachingOff() {
+	void "testPresetCanTurnCachingOff"() {
+		given:
 		grails.util.Holders.config.cache.headers.presets.presetDeny = false
-
 		con.presetTest1()
 
+		expect:
 		assertEquals 'no-cache, no-store', con.response.getHeader('Cache-Control')
 		assertNotNull con.response.getHeader('Expires')
 		assertEquals 'no-cache', con.response.getHeader('Pragma')
 	}
 
-	void testValidUntil() {
+	void "testValidUntil"() {
+		given:
 		con.validUntilTest1()
-
 		def d = con.request.getAttribute('test_validUntil')
+
+		expect:
 		assertEquals d.time.toString(), con.response.getHeader('Expires')
 	}
 
-	void testValidFor() {
+	void "testValidFor"() {
+		given:
 		con.validForTest1()
-
 		def cc = con.response.getHeader('Cache-Control').tokenize(',')*.trim()
 		def ma = cc.find { it.startsWith('max-age=') }
+
+		expect:
 		assertNotNull "Did not have max-age", ma
 		assertEquals con.request.getAttribute('test_validFor'), (ma-'max-age=').toInteger()
 	}
 
-	void testValidForNegative() {
+	void "testValidForNegative"() {
+		given:
 		con.validForTestNeg()
-
 		def cc = con.response.getHeader('Cache-Control').tokenize(',')*.trim()
 		def ma = cc.find { it.startsWith('max-age=') }
+
+		expect:
 		assertNotNull "Did not have max-age", ma
 		assertEquals 0, (ma-'max-age=').toInteger()
 	}
 
-	void testValidUntilNegative() {
+	void "testValidUntilNegative"() {
+		given:
 		con.validUntilTestNeg()
-
 		def cc = con.response.getHeader('Cache-Control').tokenize(',')*.trim()
 		def ma = cc.find { it.startsWith('max-age=') }
+
+		expect:
 		assertNotNull "Did not have max-age", ma
 		assertEquals 0, (ma-'max-age=').toInteger()
 	}
 
-	void testCombinedStoreAndShareDefault() {
+	void "testCombinedStoreAndShareDefault"() {
+		given:
 		// If we set store false, it should also default to share: private, specifying both
 		con.combinedStoreAndShareDefaultTest()
-
 		def ccParts = con.response.getHeader('Cache-Control').tokenize(',')*.trim()
+
+		expect:
 		assertTrue "Did not contain 'private'", ccParts.contains('private')
 		assertTrue "Did not contain 'no-store'", ccParts.contains('no-store')
+	}
+
+	void "testWithCacheHeadersHasRequestAndResponse"() {
+		given:
+		con.withCacheHeadersHasRequestAndResponseTest()
+
+		expect:
+		assertNotNull con.response
+		assertNotNull con.request
 	}
 
 	private String dateToHTTPDate(date) {

--- a/src/main/groovy/grails/plugins/cacheheaders/CacheHeadersTrait.groovy
+++ b/src/main/groovy/grails/plugins/cacheheaders/CacheHeadersTrait.groovy
@@ -7,9 +7,7 @@ import groovy.transform.*
 @CompileStatic
 trait CacheHeadersTrait extends ServletAttributes {
 
-	@Autowired
 	CacheHeadersService cacheHeadersService
-
 
 	void cache( boolean allow ) {
 		 cacheHeadersService.cache(response, allow) 
@@ -22,7 +20,8 @@ trait CacheHeadersTrait extends ServletAttributes {
 	void cache( Map args ) {
 		 cacheHeadersService.cache(response, args) 
 	}
-	void withCacheHeaders( Closure c) { 
+
+	boolean withCacheHeaders( Closure c) {
 		cacheHeadersService.withCacheHeaders([ response: response, request: request ], c)
 	}
 

--- a/src/main/groovy/grails/plugins/cacheheaders/CacheHeadersTrait.groovy
+++ b/src/main/groovy/grails/plugins/cacheheaders/CacheHeadersTrait.groovy
@@ -23,7 +23,7 @@ trait CacheHeadersTrait extends ServletAttributes {
 		 cacheHeadersService.cache(response, args) 
 	}
 	void withCacheHeaders( Closure c) { 
-		cacheHeadersService.withCacheHeaders(response, c) 
+		cacheHeadersService.withCacheHeaders([ response: response, request: request ], c)
 	}
 
 	void lastModified( dateOrLong ){ 

--- a/src/test/groovy/grails/plugins/cacheheaders/CacheHeadersServiceTests.groovy
+++ b/src/test/groovy/grails/plugins/cacheheaders/CacheHeadersServiceTests.groovy
@@ -1,19 +1,17 @@
 package grails.plugins.cacheheaders
 
+import junit.framework.TestCase
 
 import java.text.SimpleDateFormat
 
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 
-
 import grails.test.mixin.*
-import org.junit.*
-import test.*
 import static org.junit.Assert.*
 
 @TestFor(CacheHeadersService)
-class CacheHeadersServiceTests  {
+class CacheHeadersServiceTests extends TestCase  {
 
 	private MockHttpServletRequest req = new MockHttpServletRequest()
 	private MockHttpServletResponse resp = new MockHttpServletResponse()


### PR DESCRIPTION
The CacheHeadersTrait.withCacheHeaders method had changed from calling service method with full delegate object (in Grails 2.x) to passing in only the response (in Grails 3.x upgrades).  This broke the CacheHeadersService call inside, which expected both a "response" and a "request" on the context object.  

This PR also includes updates to get the integration and unit tests running on Grails 3.x (which they apparently were not on master).  There is also an additional integration test helping to ensure that withCacheHeaders is called with a more appropriate context object.

Hoping to get a Grails 3 tagged release for maven?  Thanks much!